### PR TITLE
Build script changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,24 +1,23 @@
 [package]
-name = "stereokit-sys"
-license = "MIT"
 description = "Low-Level Rust bindings around the StereoKitC library for XR"
-version = "0.1.1"
 edition = "2021"
-build = "build.rs"
-links = "StereoKitC"
-repository = "https://github.com/MalekiRe/stereokit-sys/"
 homepage = "https://stereokit.net/"
-readme = "README.md"
 keywords = ["stereokit", "XR", "VR", "AR", "sys"]
+license = "MIT"
+links = "StereoKitC"
+name = "stereokit-sys"
+repository = "https://github.com/MalekiRe/stereokit-sys"
+version = "0.1.1"
+
 include = [
-    "Cargo.toml",
-    "build.rs",
-    "**/src/lib.rs",
-    "dynamicwrapper.h",
-    "static-wrapper.h",
-    "StereoKit",
-    "README.md"
+  "Cargo.toml",
+  "build.rs",
+  "src/*",
+  "StereoKit",
+  "README.md",
 ]
+readme = "README.md"
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [build-dependencies]
 bindgen = "0.59.2"

--- a/build.rs
+++ b/build.rs
@@ -16,15 +16,13 @@ impl ParseCallbacks for MacroCallback {
 		self.macros.write().unwrap().insert(name.into());
 
 		match name {
-			"FP_NAN" =>{return MacroParsingBehavior::Ignore},
-			"FP_INFINITE" =>{return MacroParsingBehavior::Ignore},
-			"FP_ZERO" =>{return MacroParsingBehavior::Ignore}
-			"FP_SUBNORMAL" =>{return MacroParsingBehavior::Ignore},
-			"FP_NORMAL" =>{return MacroParsingBehavior::Ignore}
-			&_ => {}
+			"FP_NAN" =>MacroParsingBehavior::Ignore,
+			"FP_INFINITE" =>MacroParsingBehavior::Ignore,
+			"FP_ZERO" =>MacroParsingBehavior::Ignore,
+			"FP_SUBNORMAL" =>MacroParsingBehavior::Ignore,
+			"FP_NORMAL" =>MacroParsingBehavior::Ignore,
+			_ => MacroParsingBehavior::Default
 		}
-
-		MacroParsingBehavior::Default
 	}
 }
 fn main() {

--- a/build.rs
+++ b/build.rs
@@ -34,7 +34,7 @@ fn main() {
     println!("cargo:rustc-link-lib=StereoKitC");
 
     // Tell cargo to invalidate the built crate whenever the wrapper changes
-    println!("cargo:rerun-if-changed=static-wrapper.h");
+    println!("cargo:rerun-if-changed=src/static-wrapper.h");
     let macros = Arc::new(RwLock::new(HashSet::new()));
     // The bindgen::Builder is the main entry point
     // to bindgen, and lets you build up options for
@@ -42,7 +42,7 @@ fn main() {
     let bindings = bindgen::Builder::default()
         // The input header we would like to generate
         // bindings for.
-        .header("static-wrapper.h")
+        .header("src/static-wrapper.h")
         .blocklist_type("FP_NAN")
         .blocklist_type("FP_INFINITE")
         .blocklist_type("FP_ZERO")

--- a/build.rs
+++ b/build.rs
@@ -1,63 +1,65 @@
 extern crate bindgen;
 
+use bindgen::callbacks::{MacroParsingBehavior, ParseCallbacks};
 use std::collections::HashSet;
 use std::env;
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
-use bindgen::callbacks::{MacroParsingBehavior, ParseCallbacks};
 
 #[derive(Debug)]
 struct MacroCallback {
-	macros: Arc<RwLock<HashSet<String>>>,
+    macros: Arc<RwLock<HashSet<String>>>,
 }
 
 impl ParseCallbacks for MacroCallback {
-	fn will_parse_macro(&self, name: &str) -> MacroParsingBehavior {
-		self.macros.write().unwrap().insert(name.into());
+    fn will_parse_macro(&self, name: &str) -> MacroParsingBehavior {
+        self.macros.write().unwrap().insert(name.into());
 
-		match name {
-			"FP_NAN" =>MacroParsingBehavior::Ignore,
-			"FP_INFINITE" =>MacroParsingBehavior::Ignore,
-			"FP_ZERO" =>MacroParsingBehavior::Ignore,
-			"FP_SUBNORMAL" =>MacroParsingBehavior::Ignore,
-			"FP_NORMAL" =>MacroParsingBehavior::Ignore,
-			_ => MacroParsingBehavior::Default
-		}
-	}
+        match name {
+            "FP_NAN" => MacroParsingBehavior::Ignore,
+            "FP_INFINITE" => MacroParsingBehavior::Ignore,
+            "FP_ZERO" => MacroParsingBehavior::Ignore,
+            "FP_SUBNORMAL" => MacroParsingBehavior::Ignore,
+            "FP_NORMAL" => MacroParsingBehavior::Ignore,
+            _ => MacroParsingBehavior::Default,
+        }
+    }
 }
 fn main() {
-	// Tell cargo to tell rustc to link the system bzip2
-	// shared library.
+    // Tell cargo to tell rustc to link the system bzip2
+    // shared library.
 
-	let dst = cmake::build("StereoKit");
-	println!("cargo:rustc-link-search=native={}", dst.display());
-	println!("cargo:rustc-link-lib=StereoKitC");
+    let dst = cmake::build("StereoKit");
+    println!("cargo:rustc-link-search=native={}", dst.display());
+    println!("cargo:rustc-link-lib=StereoKitC");
 
-	// Tell cargo to invalidate the built crate whenever the wrapper changes
-	println!("cargo:rerun-if-changed=static-wrapper.h");
-	let macros = Arc::new(RwLock::new(HashSet::new()));
-	// The bindgen::Builder is the main entry point
-	// to bindgen, and lets you build up options for
-	// the resulting bindings.
-	let bindings = bindgen::Builder::default()
-		// The input header we would like to generate
-		// bindings for.
-		.header("static-wrapper.h")
-		.blocklist_type("FP_NAN")
-		.blocklist_type("FP_INFINITE")
-		.blocklist_type("FP_ZERO")
-		.blocklist_type("FP_SUBNORMAL")
-		.blocklist_type("FP_NORMAL")
-		.parse_callbacks(Box::new(MacroCallback {macros: macros.clone()}))
-		// Tell cargo to invalidate the built crate whenever any of the
-		// included header files changed.
-		// Finish the builder and generate the bindings.
-		.generate()
-		// Unwrap the Result and panic on failure.
-		.expect("Unable to generate bindings");
-	// Write the bindings to the $OUT_DIR/bindings.rs file.
-	let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-	bindings
-		.write_to_file(out_path.join("bindings.rs"))
-		.expect("Couldn't write bindings!");
+    // Tell cargo to invalidate the built crate whenever the wrapper changes
+    println!("cargo:rerun-if-changed=static-wrapper.h");
+    let macros = Arc::new(RwLock::new(HashSet::new()));
+    // The bindgen::Builder is the main entry point
+    // to bindgen, and lets you build up options for
+    // the resulting bindings.
+    let bindings = bindgen::Builder::default()
+        // The input header we would like to generate
+        // bindings for.
+        .header("static-wrapper.h")
+        .blocklist_type("FP_NAN")
+        .blocklist_type("FP_INFINITE")
+        .blocklist_type("FP_ZERO")
+        .blocklist_type("FP_SUBNORMAL")
+        .blocklist_type("FP_NORMAL")
+        .parse_callbacks(Box::new(MacroCallback {
+            macros: macros.clone(),
+        }))
+        // Tell cargo to invalidate the built crate whenever any of the
+        // included header files changed.
+        // Finish the builder and generate the bindings.
+        .generate()
+        // Unwrap the Result and panic on failure.
+        .expect("Unable to generate bindings");
+    // Write the bindings to the $OUT_DIR/bindings.rs file.
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("bindings.rs"))
+        .expect("Couldn't write bindings!");
 }

--- a/dynamicwrapper.h
+++ b/dynamicwrapper.h
@@ -1,5 +1,0 @@
-#include<stddef.h>
-#include<uchar.h>
-#include<stdio.h>
-#include<dynamicwrapper.h>
-#include<stereokit_ui.h>

--- a/src/static-wrapper.h
+++ b/src/static-wrapper.h
@@ -1,0 +1,2 @@
+#include "../StereoKit/StereoKitC/stereokit.h"
+#include "../StereoKit/StereoKitC/stereokit_ui.h"

--- a/static-wrapper.h
+++ b/static-wrapper.h
@@ -1,2 +1,0 @@
-#include "StereoKit/StereoKitC/stereokit.h"
-#include "StereoKit/StereoKitC/stereokit_ui.h"


### PR DESCRIPTION
Most of this is cleanup, honestly, but I'm hoping that using a more-explicitly-relative path in `static-wrapper.h` will help resolve @technobaboo's issue by forcing it to use the cloned StereoKit and not the system StereoKit for generating bindings. Maybe.