### PR TITLE
Added link targets to build on windows

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -62,6 +62,9 @@ fn main() {
 	match target_family.as_str() {
 		"windows" => {
 			cargo_link!("static=openxr_loaderd");
+			cargo_link!("windowsapp"); 
+			cargo_link!("user32"); 
+			cargo_link!("comdlg32");
 		}
 		"wasm" => {
 			unimplemented!("sorry wasm isn't implemented yet");


### PR DESCRIPTION
Added "windowsapp", "user32" and "comdlg32" as linking targets for windows.